### PR TITLE
fix: add encryption service check to health endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,18 @@
     "audit:hipaa": "node scripts/hipaa-audit.js"
   },
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "express": "^4.18.2",
+    "fhir": "^4.11.1",
+    "helmet": "^7.1.0",
+    "joi": "^17.11.0",
+    "jsonwebtoken": "^9.0.2",
+    "node-cron": "^3.0.3",
     "pg": "^8.11.3",
     "redis": "^4.6.10",
-    "jsonwebtoken": "^9.0.2",
-    "bcrypt": "^5.1.1",
-    "helmet": "^7.1.0",
-    "winston": "^3.11.0",
-    "joi": "^17.11.0",
-    "fhir": "^4.11.1",
-    "node-cron": "^3.0.3"
+    "winston": "^3.11.0"
+  },
+  "devDependencies": {
+    "jest": "^30.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const helmet = require('helmet');
 const { logger } = require('./utils/logger');
+const { checkHealth: checkEncryptionHealth } = require('./utils/encryption');
 const hipaaAudit = require('./middleware/hipaaAudit');
 const authMiddleware = require('./middleware/auth');
 
@@ -17,8 +18,24 @@ app.use('/api/v1/providers', authMiddleware, require('./api/providers'));
 app.use('/api/v1/consent', authMiddleware, require('./api/consent'));
 app.use('/fhir/r4', authMiddleware, require('./api/fhir'));
 
-app.get('/health', (req, res) => res.json({ status: 'ok' }));
+app.get('/health', (req, res) => {
+  const encryption = checkEncryptionHealth();
+  const checks = { encryption };
+  const isHealthy = encryption.healthy;
+
+  if (!isHealthy) {
+    logger.error('Health check failed: encryption service unavailable', { checks });
+  }
+
+  const statusCode = isHealthy ? 200 : 503;
+  res.status(statusCode).json({
+    status: isHealthy ? 'ok' : 'unhealthy',
+    checks
+  });
+});
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => logger.info(`MedSecure running on port ${PORT}`));
+if (require.main === module) {
+  app.listen(PORT, () => logger.info(`MedSecure running on port ${PORT}`));
+}
 module.exports = app;

--- a/src/utils/encryption.js
+++ b/src/utils/encryption.js
@@ -20,4 +20,24 @@ function decrypt(data) {
   return decrypted;
 }
 
-module.exports = { encrypt, decrypt };
+function checkHealth() {
+  try {
+    if (!process.env.ENCRYPTION_KEY) {
+      return { healthy: false, reason: 'ENCRYPTION_KEY not configured' };
+    }
+    if (KEY.length !== 32) {
+      return { healthy: false, reason: 'ENCRYPTION_KEY must be 256 bits (32 bytes)' };
+    }
+    const testPlaintext = 'phi-encryption-health-check';
+    const encrypted = encrypt(testPlaintext);
+    const decrypted = decrypt(encrypted);
+    if (decrypted !== testPlaintext) {
+      return { healthy: false, reason: 'Encrypt/decrypt round-trip verification failed' };
+    }
+    return { healthy: true };
+  } catch (err) {
+    return { healthy: false, reason: `Encryption service error: ${err.message}` };
+  }
+}
+
+module.exports = { encrypt, decrypt, checkHealth };

--- a/tests/encryption.test.js
+++ b/tests/encryption.test.js
@@ -1,0 +1,52 @@
+const crypto = require('crypto');
+
+describe('encryption checkHealth', () => {
+  const VALID_KEY = crypto.randomBytes(32).toString('hex');
+  const originalEnv = process.env.ENCRYPTION_KEY;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.ENCRYPTION_KEY = originalEnv;
+    } else {
+      delete process.env.ENCRYPTION_KEY;
+    }
+    jest.resetModules();
+  });
+
+  function loadEncryption(key) {
+    if (key !== undefined) {
+      process.env.ENCRYPTION_KEY = key;
+    } else {
+      delete process.env.ENCRYPTION_KEY;
+    }
+    return require('../src/utils/encryption');
+  }
+
+  test('returns healthy when ENCRYPTION_KEY is valid', () => {
+    const { checkHealth } = loadEncryption(VALID_KEY);
+    const result = checkHealth();
+    expect(result.healthy).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  test('returns unhealthy when ENCRYPTION_KEY is not set', () => {
+    const { checkHealth } = loadEncryption(undefined);
+    const result = checkHealth();
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/not configured/i);
+  });
+
+  test('returns unhealthy when ENCRYPTION_KEY is empty string', () => {
+    const { checkHealth } = loadEncryption('');
+    const result = checkHealth();
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/not configured/i);
+  });
+
+  test('returns unhealthy when ENCRYPTION_KEY is wrong length', () => {
+    const { checkHealth } = loadEncryption('abcd1234');
+    const result = checkHealth();
+    expect(result.healthy).toBe(false);
+    expect(result.reason).toMatch(/256 bits/i);
+  });
+});

--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -1,0 +1,104 @@
+const crypto = require('crypto');
+const http = require('http');
+
+const VALID_KEY = crypto.randomBytes(32).toString('hex');
+
+jest.mock('../src/middleware/hipaaAudit', () => (req, res, next) => next());
+jest.mock('../src/middleware/auth', () => (req, res, next) => next());
+jest.mock('../src/models/db', () => jest.fn());
+jest.mock('../src/api/patients', () => require('express').Router());
+jest.mock('../src/api/records', () => require('express').Router());
+jest.mock('../src/api/appointments', () => require('express').Router());
+jest.mock('../src/api/prescriptions', () => require('express').Router());
+jest.mock('../src/api/providers', () => require('express').Router(), { virtual: true });
+jest.mock('../src/api/consent', () => require('express').Router());
+jest.mock('../src/api/fhir', () => require('express').Router(), { virtual: true });
+
+function loadAppWithKey(key) {
+  if (key !== undefined) {
+    process.env.ENCRYPTION_KEY = key;
+  } else {
+    delete process.env.ENCRYPTION_KEY;
+  }
+  jest.resetModules();
+  jest.mock('../src/middleware/hipaaAudit', () => (req, res, next) => next());
+  jest.mock('../src/middleware/auth', () => (req, res, next) => next());
+  jest.mock('../src/models/db', () => jest.fn());
+  jest.mock('../src/api/patients', () => require('express').Router());
+  jest.mock('../src/api/records', () => require('express').Router());
+  jest.mock('../src/api/appointments', () => require('express').Router());
+  jest.mock('../src/api/prescriptions', () => require('express').Router());
+  jest.mock('../src/api/providers', () => require('express').Router(), { virtual: true });
+  jest.mock('../src/api/consent', () => require('express').Router());
+  jest.mock('../src/api/fhir', () => require('express').Router(), { virtual: true });
+  return require('../src/index');
+}
+
+function makeRequest(port, path) {
+  return new Promise((resolve, reject) => {
+    http.get(`http://localhost:${port}${path}`, (res) => {
+      let body = '';
+      res.on('data', (chunk) => (body += chunk));
+      res.on('end', () => {
+        resolve({ statusCode: res.statusCode, body: JSON.parse(body) });
+      });
+    }).on('error', reject);
+  });
+}
+
+describe('/health endpoint', () => {
+  const originalEnv = process.env.ENCRYPTION_KEY;
+  let server;
+
+  afterEach((done) => {
+    if (originalEnv !== undefined) {
+      process.env.ENCRYPTION_KEY = originalEnv;
+    } else {
+      delete process.env.ENCRYPTION_KEY;
+    }
+    jest.resetModules();
+    if (server && server.close) {
+      server.close(done);
+    } else {
+      done();
+    }
+  });
+
+  test('returns 200 and status ok when encryption is healthy', (done) => {
+    const app = loadAppWithKey(VALID_KEY);
+    server = app.listen(0, async () => {
+      const port = server.address().port;
+      const { statusCode, body } = await makeRequest(port, '/health');
+      expect(statusCode).toBe(200);
+      expect(body.status).toBe('ok');
+      expect(body.checks.encryption.healthy).toBe(true);
+      done();
+    });
+  });
+
+  test('returns 503 and unhealthy status when encryption key is missing', (done) => {
+    const app = loadAppWithKey(undefined);
+    server = app.listen(0, async () => {
+      const port = server.address().port;
+      const { statusCode, body } = await makeRequest(port, '/health');
+      expect(statusCode).toBe(503);
+      expect(body.status).toBe('unhealthy');
+      expect(body.checks.encryption.healthy).toBe(false);
+      expect(body.checks.encryption.reason).toMatch(/not configured/i);
+      done();
+    });
+  });
+
+  test('returns 503 when encryption key has wrong length', (done) => {
+    const app = loadAppWithKey('abcd1234');
+    server = app.listen(0, async () => {
+      const port = server.address().port;
+      const { statusCode, body } = await makeRequest(port, '/health');
+      expect(statusCode).toBe(503);
+      expect(body.status).toBe('unhealthy');
+      expect(body.checks.encryption.healthy).toBe(false);
+      expect(body.checks.encryption.reason).toMatch(/256 bits/i);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #52 — The `/health` endpoint now verifies PHI encryption service availability before reporting healthy status.

## Problem

The health check always returned `{"status": "ok"}` regardless of whether the encryption service was functional. This meant:
1. **Write operations** could store PHI data unencrypted
2. **Read operations** could return encrypted (unreadable) data
3. Load balancers would continue routing traffic to unhealthy instances

## Solution

### `src/utils/encryption.js`
- Added `checkHealth()` function that performs a full round-trip encryption/decryption verification
- Checks: ENCRYPTION_KEY is set, key is correct length (256 bits), encrypt→decrypt round-trip succeeds

### `src/index.js`
- Updated `/health` endpoint to call `checkEncryptionHealth()` before responding
- Returns **200** with `{"status": "ok", "checks": {"encryption": {"healthy": true}}}` when healthy
- Returns **503** with `{"status": "unhealthy", "checks": {"encryption": {"healthy": false, "reason": "..."}}}` when unhealthy
- Logs error details when health check fails
- Guarded `app.listen()` with `require.main === module` for testability

### Tests
- `tests/encryption.test.js` — 4 tests covering valid key, missing key, empty key, wrong-length key
- `tests/health.test.js` — 3 integration tests verifying HTTP status codes and response bodies for healthy/unhealthy states

All 7 tests pass.