### PR TITLE
fix: add HIPAA-required audit logging for patient record access (#63)

### DIFF
--- a/src/api/records.js
+++ b/src/api/records.js
@@ -1,11 +1,28 @@
 const router = require('express').Router();
 const RecordService = require('../services/recordService');
 const { formatErrorResponse } = require('../utils/errorCodes');
+const { logger } = require('../utils/logger');
+
+/**
+ * Create a HIPAA-compliant audit log entry for record operations.
+ */
+function auditLog(action, { patientId, recordId, userId }) {
+  logger.info({
+    type: 'HIPAA_AUDIT',
+    action,
+    patientId,
+    recordId,
+    userId,
+    timestamp: new Date().toISOString()
+  });
+}
 
 router.get('/patient/:patientId', async (req, res) => {
   try {
+    const { patientId } = req.params;
     const { page, limit } = req.query;
-    const records = await RecordService.getByPatient(req.params.patientId, req.user, { page, limit });
+    const records = await RecordService.getByPatient(patientId, req.user, { page, limit });
+    auditLog('record_access', { patientId, userId: req.user?.id });
     res.json(records);
   } catch (err) {
     const { status, body } = formatErrorResponse(err);
@@ -15,6 +32,7 @@ router.get('/patient/:patientId', async (req, res) => {
 router.post('/', async (req, res) => {
   try {
     const record = await RecordService.create(req.body, req.user);
+    auditLog('record_create', { patientId: req.body.patient_id, recordId: record.id, userId: req.user?.id });
     res.status(201).json(record);
   } catch (err) {
     const { status, body } = formatErrorResponse(err);
@@ -24,6 +42,7 @@ router.post('/', async (req, res) => {
 router.get('/:id', async (req, res) => {
   try {
     const record = await RecordService.getById(req.params.id, req.user);
+    auditLog('record_access', { patientId: record.patient_id, recordId: record.id, userId: req.user?.id });
     res.json(record);
   } catch (err) {
     const { status, body } = formatErrorResponse(err);
@@ -31,3 +50,4 @@ router.get('/:id', async (req, res) => {
   }
 });
 module.exports = router;
+module.exports.auditLog = auditLog;

--- a/tests/recordAccessAudit.test.js
+++ b/tests/recordAccessAudit.test.js
@@ -1,0 +1,183 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}));
+
+jest.mock('../src/services/recordService', () => ({
+  getByPatient: jest.fn(),
+  getById: jest.fn(),
+  create: jest.fn()
+}));
+
+const { logger } = require('../src/utils/logger');
+const RecordService = require('../src/services/recordService');
+const recordsRouter = require('../src/api/records');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  // Simulate auth middleware attaching user
+  app.use((req, _res, next) => {
+    req.user = { id: 'user-42', role: 'provider' };
+    next();
+  });
+  app.use('/records', recordsRouter);
+  return app;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Record access audit logging', () => {
+  describe('GET /records/patient/:patientId', () => {
+    it('should log a record_access audit entry with patientId and userId', async () => {
+      RecordService.getByPatient.mockResolvedValue({
+        data: [{ id: 'rec-1' }],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 }
+      });
+
+      const app = createApp();
+      await request(app).get('/records/patient/patient-100').expect(200);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'HIPAA_AUDIT',
+          action: 'record_access',
+          patientId: 'patient-100',
+          userId: 'user-42'
+        })
+      );
+    });
+
+    it('should include a valid ISO timestamp in the audit entry', async () => {
+      RecordService.getByPatient.mockResolvedValue({
+        data: [],
+        pagination: { page: 1, limit: 20, total: 0, totalPages: 0 }
+      });
+
+      const app = createApp();
+      await request(app).get('/records/patient/patient-200').expect(200);
+
+      const logCall = logger.info.mock.calls[0][0];
+      expect(logCall.timestamp).toBeDefined();
+      expect(new Date(logCall.timestamp).getTime()).not.toBeNaN();
+    });
+
+    it('should not log an audit entry when service throws an error', async () => {
+      RecordService.getByPatient.mockRejectedValue(
+        Object.assign(new Error('Not found'), { code: 'RECORD_NOT_FOUND' })
+      );
+
+      const app = createApp();
+      await request(app).get('/records/patient/bad-id').expect(404);
+
+      expect(logger.info).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'record_access' })
+      );
+    });
+  });
+
+  describe('GET /records/:id', () => {
+    it('should log a record_access audit entry with patientId, recordId, and userId', async () => {
+      RecordService.getById.mockResolvedValue({
+        id: 'rec-55',
+        patient_id: 'patient-300'
+      });
+
+      const app = createApp();
+      await request(app).get('/records/rec-55').expect(200);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'HIPAA_AUDIT',
+          action: 'record_access',
+          patientId: 'patient-300',
+          recordId: 'rec-55',
+          userId: 'user-42'
+        })
+      );
+    });
+
+    it('should not log an audit entry when record is not found', async () => {
+      RecordService.getById.mockRejectedValue(
+        Object.assign(new Error('Record not found'), { code: 'RECORD_NOT_FOUND' })
+      );
+
+      const app = createApp();
+      await request(app).get('/records/nonexistent').expect(404);
+
+      expect(logger.info).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'record_access' })
+      );
+    });
+  });
+
+  describe('POST /records', () => {
+    it('should log a record_create audit entry with patientId, recordId, and userId', async () => {
+      RecordService.create.mockResolvedValue({
+        id: 'rec-99',
+        patient_id: 'patient-400'
+      });
+
+      const app = createApp();
+      await request(app)
+        .post('/records')
+        .send({ patient_id: 'patient-400', type: 'lab_result', data: {} })
+        .expect(201);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'HIPAA_AUDIT',
+          action: 'record_create',
+          patientId: 'patient-400',
+          recordId: 'rec-99',
+          userId: 'user-42'
+        })
+      );
+    });
+
+    it('should not log an audit entry when record creation fails', async () => {
+      RecordService.create.mockRejectedValue(new Error('DB error'));
+
+      const app = createApp();
+      await request(app)
+        .post('/records')
+        .send({ patient_id: 'patient-500' })
+        .expect(500);
+
+      expect(logger.info).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'record_create' })
+      );
+    });
+  });
+
+  describe('auditLog helper', () => {
+    const { auditLog } = require('../src/api/records');
+
+    it('should log with type HIPAA_AUDIT and the given action', () => {
+      auditLog('record_access', { patientId: 'p-1', userId: 'u-1' });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'HIPAA_AUDIT',
+          action: 'record_access',
+          patientId: 'p-1',
+          userId: 'u-1'
+        })
+      );
+    });
+
+    it('should include recordId when provided', () => {
+      auditLog('record_access', { patientId: 'p-2', recordId: 'r-2', userId: 'u-2' });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recordId: 'r-2'
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #63 — Patient record access was missing HIPAA-required audit log entries.

## Changes

### `src/api/records.js`
- Added `auditLog` helper that emits structured `HIPAA_AUDIT` entries via winston logger
- **GET `/patient/:patientId`** — logs `record_access` with `patientId` and `userId`
- **GET `/:id`** — logs `record_access` with `patientId`, `recordId`, and `userId`
- **POST `/`** — logs `record_create` with `patientId`, `recordId`, and `userId`
- Each audit entry includes ISO timestamp for compliance traceability
- Audit entries are only emitted on successful operations (not on errors)

### `tests/recordAccessAudit.test.js`
- 9 tests covering all three routes and the helper function
- Verifies audit entries contain correct `type`, `action`, `patientId`, `userId`, `recordId`
- Verifies valid ISO timestamps
- Verifies no audit entries are logged on failed operations

## Audit Log Format
```json
{
  "type": "HIPAA_AUDIT",
  "action": "record_access",
  "patientId": "patient-123",
  "recordId": "rec-456",
  "userId": "user-789",
  "timestamp": "2026-04-06T05:10:00.000Z"
}
```

## Testing
- All 9 new tests pass
- Existing `records.test.js` tests continue to pass
- ESLint clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/febuniac/medsecure/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
