### PR TITLE
fix: add auth middleware to records routes - PHI protection (Fixes #62)

### DIFF
--- a/src/api/records.js
+++ b/src/api/records.js
@@ -2,6 +2,7 @@ const router = require('express').Router();
 const RecordService = require('../services/recordService');
 const { formatErrorResponse } = require('../utils/errorCodes');
 const { logger } = require('../utils/logger');
+const authMiddleware = require('../middleware/auth');
 
 /**
  * Create a HIPAA-compliant audit log entry for record operations.
@@ -17,7 +18,7 @@ function auditLog(action, { patientId, recordId, userId }) {
   });
 }
 
-router.get('/patient/:patientId', async (req, res) => {
+router.get('/patient/:patientId', authMiddleware, async (req, res) => {
   try {
     const { patientId } = req.params;
     const { page, limit } = req.query;
@@ -29,7 +30,7 @@ router.get('/patient/:patientId', async (req, res) => {
     res.status(status).json(body);
   }
 });
-router.post('/', async (req, res) => {
+router.post('/', authMiddleware, async (req, res) => {
   try {
     const record = await RecordService.create(req.body, req.user);
     auditLog('record_create', { patientId: req.body.patient_id, recordId: record.id, userId: req.user?.id });
@@ -39,7 +40,7 @@ router.post('/', async (req, res) => {
     res.status(status).json(body);
   }
 });
-router.get('/patient/:patientId/lab-results', async (req, res) => {
+router.get('/patient/:patientId/lab-results', authMiddleware, async (req, res) => {
   try {
     const { page, limit } = req.query;
     const results = await RecordService.getLabResults(req.params.patientId, req.user, { page, limit });
@@ -49,7 +50,7 @@ router.get('/patient/:patientId/lab-results', async (req, res) => {
     res.status(status).json(body);
   }
 });
-router.get('/:id', async (req, res) => {
+router.get('/:id', authMiddleware, async (req, res) => {
   try {
     const record = await RecordService.getById(req.params.id, req.user);
     auditLog('record_access', { patientId: record.patient_id, recordId: record.id, userId: req.user?.id });

--- a/tests/recordsAuth.test.js
+++ b/tests/recordsAuth.test.js
@@ -1,0 +1,123 @@
+const jwt = require('jsonwebtoken');
+const express = require('express');
+const request = require('supertest');
+
+const TEST_SECRET = 'test-jwt-secret-key';
+
+beforeAll(() => {
+  process.env.JWT_SECRET = TEST_SECRET;
+});
+
+const { generateToken } = require('../src/middleware/auth');
+
+// Mock the db module
+jest.mock('../src/models/db', () => {
+  const mockQuery = {
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockResolvedValue([]),
+    count: jest.fn().mockReturnThis(),
+    first: jest.fn().mockResolvedValue({ total: 0 }),
+    insert: jest.fn().mockReturnThis(),
+    returning: jest.fn().mockResolvedValue([{ id: 'rec-1', patient_id: 'p-1' }]),
+    select: jest.fn().mockResolvedValue([]),
+  };
+  const db = jest.fn(() => mockQuery);
+  db._mockQuery = mockQuery;
+  return db;
+});
+
+// Mock providerPatientService to avoid DB calls
+jest.mock('../src/services/providerPatientService', () => ({
+  verifyAccess: jest.fn().mockResolvedValue(true),
+}));
+
+const recordsRouter = require('../src/api/records');
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  // Mount records router WITHOUT router-level auth to isolate route-level auth
+  app.use('/records', recordsRouter);
+  return app;
+}
+
+describe('Records API - Authentication Enforcement', () => {
+  let app;
+
+  beforeEach(() => {
+    app = createApp();
+    jest.clearAllMocks();
+  });
+
+  describe('GET /records/:id', () => {
+    it('should return 401 when no auth token is provided', async () => {
+      const res = await request(app).get('/records/rec-123');
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 401 when an invalid token is provided', async () => {
+      const res = await request(app)
+        .get('/records/rec-123')
+        .set('Authorization', 'Bearer invalid-token');
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should allow access with a valid auth token', async () => {
+      const db = require('../src/models/db');
+      db._mockQuery.first.mockResolvedValueOnce({ id: 'rec-123', patient_id: 'p-1' });
+      db._mockQuery.select.mockResolvedValueOnce([]);
+
+      const token = generateToken({ id: 'user-1', email: 'doc@medsecure.com', role: 'physician' });
+      const res = await request(app)
+        .get('/records/rec-123')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).not.toBe(401);
+    });
+  });
+
+  describe('GET /records/patient/:patientId', () => {
+    it('should return 401 when no auth token is provided', async () => {
+      const res = await request(app).get('/records/patient/p-123');
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 401 when an invalid token is provided', async () => {
+      const res = await request(app)
+        .get('/records/patient/p-123')
+        .set('Authorization', 'Bearer bad-token');
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+
+  describe('POST /records', () => {
+    it('should return 401 when no auth token is provided', async () => {
+      const res = await request(app)
+        .post('/records')
+        .send({ patient_id: 'p-1', type: 'note', content: 'test' });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBeDefined();
+    });
+
+    it('should return 401 when an invalid token is provided', async () => {
+      const res = await request(app)
+        .post('/records')
+        .send({ patient_id: 'p-1', type: 'note', content: 'test' })
+        .set('Authorization', 'Bearer expired-token');
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #62 — PHI was accessible without authentication on the records API endpoints.

### Problem

In `src/api/records.js`, the GET `/records/:id` endpoint (and other records routes) did not enforce authentication at the route level. While auth middleware was applied at the router mount level in `v1Router.js` and `index.js`, this left the individual routes without defense-in-depth protection, violating HIPAA security requirements for PHI access controls.

### Fix

Added `authMiddleware` directly to all three records routes as defense-in-depth:
- `GET /records/:id` — fetches a specific medical record
- `GET /records/patient/:patientId` — fetches records by patient
- `POST /records/` — creates a new record

This ensures that even if the router-level middleware is accidentally removed or bypassed, individual routes still enforce authentication.

### Tests

Added `tests/recordsAuth.test.js` with 7 tests:
- Verifies 401 returned for unauthenticated requests to all 3 routes
- Verifies 401 returned for invalid tokens on all 3 routes
- Verifies authenticated requests succeed with valid JWT

All new tests pass. No regressions introduced (6 pre-existing test failures confirmed on main).

### Labels
`security`, `critical`, `HIPAA`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/febuniac/medsecure/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
